### PR TITLE
Fix for foundry v12 grid warnings

### DIFF
--- a/system.json
+++ b/system.json
@@ -25,6 +25,10 @@
   "download": "https://github.com/Cussa/fvtt-troika/releases/download/1.5.0/system.zip",
   "gridDistance": 1,
   "gridUnits": "m",
+  "grid": {
+    "distance": 1,
+    "units": "m"
+  },
   "primaryTokenAttribute": "stamina",
   "secondaryTokenAttribute": "luck",
   "esmodules": [


### PR DESCRIPTION
The following warnings appear when using using Foundry v12:

```
The system "troika" is using "gridDistance" which is deprecated in favor of "grid.distance".
The system "troika" is using "gridUnits" which is deprecated in favor of "grid.units".
```

This should fix that while maintaining compatibility with v11 and prior versions. The old "gridDistance" and "gridUnits" fields can be removed once capability with versions prior to v12 is removed.